### PR TITLE
Separate message for Monitoring 

### DIFF
--- a/scala-package/src/main/scala/io/hydrosphere/serving/grpc/HeaderClientServerInterceptor.scala
+++ b/scala-package/src/main/scala/io/hydrosphere/serving/grpc/HeaderClientServerInterceptor.scala
@@ -1,5 +1,7 @@
 package io.hydrosphere.serving.grpc
 
+import java.util.concurrent.atomic.AtomicReference
+
 import io.grpc._
 
 class HeaderClientServerInterceptor(header: String) extends ServerInterceptor with ClientInterceptor {
@@ -9,6 +11,7 @@ class HeaderClientServerInterceptor(header: String) extends ServerInterceptor wi
   lazy val contextKey: Context.Key[String] = Context.key(header)
 
   lazy val callOptionsKey: CallOptions.Key[String] = CallOptions.Key.of(header, null)
+  lazy val callOptionsClientResponseWrapperKey: CallOptions.Key[AtomicReference[String]] = CallOptions.Key.of(header, null)
 
 
   override def interceptCall[ReqT, RespT](call: ServerCall[ReqT, RespT], requestHeaders: Metadata, next: ServerCallHandler[ReqT, RespT]): ServerCall.Listener[ReqT] = {
@@ -19,14 +22,46 @@ class HeaderClientServerInterceptor(header: String) extends ServerInterceptor wi
   }
 
   override def interceptCall[ReqT, RespT](method: MethodDescriptor[ReqT, RespT], callOptions: CallOptions, next: Channel): ClientCall[ReqT, RespT] = {
-    val destination = callOptions.getOption(callOptionsKey)
+    val metadataValue = callOptions.getOption(callOptionsKey)
+    val responseHeaderWrapper = callOptions.getOption(callOptionsClientResponseWrapperKey)
+
     new ForwardingClientCall.SimpleForwardingClientCall[ReqT, RespT](next.newCall(method, callOptions)) {
       override def start(responseListener: ClientCall.Listener[RespT], headers: Metadata): Unit = {
-        if (destination != null) headers.put(metadataKey, destination)
-        super.start(responseListener, headers)
+        if (metadataValue != null) headers.put(metadataKey, metadataValue)
+
+        val listener = if (responseHeaderWrapper != null) {
+          new ContextualizedClientCallListener[RespT](responseListener, responseHeaderWrapper)
+        } else {
+          responseListener
+        }
+
+        super.start(listener, headers)
       }
     }
   }
+
+  private class ContextualizedClientCallListener[RespT](val delegate: ClientCall.Listener[RespT], headerWrapper: AtomicReference[String]) extends ClientCall.Listener[RespT] {
+
+    override def onHeaders(headers: Metadata): Unit = {
+      if (headers.containsKey(metadataKey)) {
+        headerWrapper.set(headers.get(metadataKey))
+      }
+      delegate.onHeaders(headers)
+    }
+
+    override def onMessage(message: RespT): Unit = {
+      delegate.onMessage(message)
+    }
+
+    override def onClose(status: Status, trailers: Metadata): Unit = {
+      delegate.onClose(status, trailers)
+    }
+
+    override def onReady(): Unit = {
+      delegate.onReady()
+    }
+  }
+
 }
 
 object HeaderClientServerInterceptor {

--- a/scala-package/src/main/scala/io/hydrosphere/serving/grpc/Headers.scala
+++ b/scala-package/src/main/scala/io/hydrosphere/serving/grpc/Headers.scala
@@ -1,5 +1,7 @@
 package io.hydrosphere.serving.grpc
 
+import java.util.concurrent.atomic.AtomicReference
+
 import io.grpc.{CallOptions, Context, Metadata}
 
 sealed trait Header {
@@ -10,36 +12,27 @@ sealed trait Header {
   def metadataKey: Metadata.Key[String] = interceptor.metadataKey
   def contextKey: Context.Key[String] = interceptor.contextKey
   def callOptionsKey: CallOptions.Key[String] = interceptor.callOptionsKey
+  def callOptionsClientResponseWrapperKey: CallOptions.Key[AtomicReference[String]] = interceptor.callOptionsClientResponseWrapperKey
 }
 
 object Headers {
-  
-  object KafkaTopic extends Header {
-    override val name: String = "kafka_produce_topic"
+
+  object XEnvoyUpstreamServiceTime extends Header {
+    override val name: String = "x-envoy-upstream-service-time"
   }
-  
-  object ApplicationId extends Header {
-    override val name: String = "application_id"
+
+  object XServingModelVersionId extends Header {
+    override val name: String = "x-serving-model-version-id"
   }
-  
-  object TraceId extends Header {
-    override val name: String = "trace_id"
+
+  object XServingKafkaProduceTopic extends Header {
+    override val name: String = "x-serving-kafka-produce-topic"
   }
-  
-  object StageId extends Header {
-    override val name: String = "stage_id"
-  }
-  
-  object StageName extends Header {
-    override val name: String = "stage_name"
-  }
-  
+
   val all: Seq[Header] = Seq(
-    KafkaTopic,
-    ApplicationId,
-    TraceId,
-    StageId,
-    StageName
+    XServingKafkaProduceTopic,
+    XEnvoyUpstreamServiceTime,
+    XServingModelVersionId
   )
 
   def interceptors: Seq[HeaderClientServerInterceptor] = all.map(_.interceptor)

--- a/src/hydro_serving_grpc/monitoring/monitoring.proto
+++ b/src/hydro_serving_grpc/monitoring/monitoring.proto
@@ -13,11 +13,10 @@ message ExecutionError{
 message ExecutionMetadata{
     int64 application_id = 1;
     string stage_id = 2;
-    int64 model_id = 3;
-    int64 modelVersion_id = 4;
-    string signature_name = 5;
-    string request_id = 6;
-    string application_request_id = 7;
+    int64 modelVersion_id = 3;
+    string signature_name = 4;
+    string request_id = 5;
+    string application_request_id = 6;
 }
 
 message ExecutionInformation{


### PR DESCRIPTION
- added to fetch headers from server Response callOptionsClientResponseWrapperKey
- Renamed headers
- removed model_id from monitoring.proto